### PR TITLE
Use faster version of host extraction

### DIFF
--- a/opera/chrome/scripts/utils.js
+++ b/opera/chrome/scripts/utils.js
@@ -27,10 +27,9 @@ function onReady(callback) {
 }
 
 function getHost(url) {
-  ANCHOR.href = url;
-  return ANCHOR.host;
+  // https://issues.adblockplus.org/ticket/7296/
+  return /^(?:[^:]+:)(?:\/\/(?:[^/]*@)?([^/]+))?/.exec(url)[1] || '';
 }
 
 const EXTENSION = chrome.extension;
 const BROWSER_ACTION = chrome.browserAction;
-const ANCHOR = document.createElement('a');


### PR DESCRIPTION
See https://issues.adblockplus.org/ticket/7296/

Since the URLs returned by the APIs in use are already canonicalized, there's no need to use a DOM element to extract the host.