### PR TITLE
Fix UpdateReceiver changing the PACKAGE_REPLACED to the MY_PACKAGE_RE…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,10 +30,9 @@
         <meta-data
             android:name="com.samsung.android.sbrowser.contentBlocker.interfaceVersion"
             android:value="API_1.0" />
-        <receiver android:name=".service.UpdateReceiver" android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.PACKAGE_REPLACED" />
-                <data android:scheme="package" />
+        <receiver android:name=".service.UpdateReceiver" android:exported="true" android:enabled="true">
+            <intent-filter >
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
     </application>

--- a/android/app/src/main/java/com/rocketshipapps/adblockfast/service/UpdateReceiver.java
+++ b/android/app/src/main/java/com/rocketshipapps/adblockfast/service/UpdateReceiver.java
@@ -3,20 +3,13 @@ package com.rocketshipapps.adblockfast.service;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.net.Uri;
 
 import com.rocketshipapps.adblockfast.AdblockFastApplication;
 
 public class UpdateReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
-        Uri data = intent.getData();
-
-        if (
-            "android.intent.action.PACKAGE_REPLACED".equals(intent.getAction()) &&
-                data != null &&
-                context.getPackageName().equals(data.getSchemeSpecificPart())
-        ) {
+        if ("android.intent.action.MY_PACKAGE_REPLACED".equals(intent.getAction())) {
             AdblockFastApplication.dumpPrefs();
             AdblockFastApplication.updateLegacyPrefs(context);
             AdblockFastApplication.dumpPrefs();


### PR DESCRIPTION
Apps that target Android 8.0 or higher can no longer register broadcast receivers for implicit broadcasts in their manifest unless the broadcast is restricted to that app specifically. An implicit broadcast is a broadcast that does not target a specific component within an app. For example, ACTION_PACKAGE_REPLACED is sent to all registered listeners across all apps, letting them know that some package on the device was replaced. Because the broadcast is implicit, it will not be delivered to manifest-registered receivers in apps that target Android 8.0 or higher. ACTION_MY_PACKAGE_REPLACED is also an implicit broadcast, but since it is sent only to the app whose package was replaced it will be delivered to manifest-registered receivers.